### PR TITLE
fix: libcxx 19 removes std::char_traits<uint32_t>

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -44,6 +44,14 @@ std::string ustringToUTF8(const UString &ustr) {
     return result;
 }
 
+UString ucsToUString(const ucschar *str) {
+    UString result;
+    while (*str) {
+        result += *str++;
+    }
+    return result;
+}
+
 static std::string subUTF8String(const std::string &str, int p1, int p2) {
     int limit;
     int pos;
@@ -131,7 +139,7 @@ public:
 
         auto hic_preedit = hangul_ic_get_preedit_string(context_.get());
         UString preedit = preedit_;
-        preedit.append(UString(hic_preedit));
+        preedit.append(ucsToUString(hic_preedit));
         if (!preedit.empty()) {
             auto utf8 = ustringToUTF8(preedit);
             if (*engine_->config().wordCommit || *engine_->config().hanjaMode) {
@@ -356,10 +364,8 @@ public:
                 const ucschar *hic_preedit;
 
                 hic_preedit = hangul_ic_get_preedit_string(context_.get());
-                if (hic_preedit != nullptr && hic_preedit[0] != 0) {
-                    preedit_.append(UString(str));
-                } else {
-                    preedit_.append(UString(str));
+                preedit_.append(ucsToUString(str));
+                if (hic_preedit == nullptr || hic_preedit[0] == 0) {
                     if (!preedit_.empty()) {
                         auto commit = ustringToUTF8(preedit_);
                         if (!commit.empty()) {
@@ -370,7 +376,7 @@ public:
                 }
             } else {
                 if (str != nullptr && str[0] != 0) {
-                    auto commit = ustringToUTF8(str);
+                    auto commit = ustringToUTF8(ucsToUString(str));
                     if (!commit.empty()) {
                         ic_->commitString(commit);
                     }
@@ -408,7 +414,7 @@ public:
 
         auto str = hangul_ic_flush(context_.get());
 
-        preedit_ += str;
+        preedit_ += ucsToUString(str);
 
         if (preedit_.empty())
             return;
@@ -430,7 +436,7 @@ public:
         std::string pre1 = ustringToUTF8(preedit_);
         std::string pre2;
         if (hic_preedit) {
-            pre2 = ustringToUTF8(hic_preedit);
+            pre2 = ustringToUTF8(ucsToUString(hic_preedit));
         }
 
         if (!pre1.empty() || !pre2.empty()) {
@@ -493,7 +499,7 @@ public:
 
         key_len = fcitx::utf8::length(std::string(key));
         preedit_len = preedit_.size();
-        hic_preedit_len = UString(hic_preedit).size();
+        hic_preedit_len = ucsToUString(hic_preedit).size();
 
         bool surrounding = false;
         if (lastLookupMethod_ == LOOKUP_METHOD_PREFIX) {

--- a/src/engine.h
+++ b/src/engine.h
@@ -85,7 +85,9 @@ typedef enum _LookupMethod {
 
 class HangulState;
 
-using UString = std::basic_string<uint32_t>;
+using UString = std::basic_string<char32_t>;
+
+UString ucsToUString(const ucschar *c);
 
 class HangulEngine : public InputMethodEngine {
 public:


### PR DESCRIPTION
```
FAILED: fcitx5-hangul/src/CMakeFiles/hangul.dir/engine.cpp.o 
/Users/liumeo/github/emsdk/upstream/emscripten/em++ -DFCITX_GETTEXT_DOMAIN=\"fcitx5-hangul\" -DFCITX_INSTALL_LOCALEDIR=\"/usr/share/locale\" -D_GNU_SOURCE -Dhangul_EXPORTS -isystem /Users/liumeo/github/fcitx5-plugins/build/js/usr/include/Fcitx5/Core -isystem /Users/liumeo/github/fcitx5-plugins/build/js/usr/include/Fcitx5/Config -isystem /Users/liumeo/github/fcitx5-plugins/build/js/usr/include/Fcitx5/Utils -isystem /Users/liumeo/github/fcitx5-plugins/build/js/usr/include/hangul-1.0 -Wall -Wextra  -O3 -DNDEBUG -std=c++17 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -fPIC -fexceptions -MD -MT fcitx5-hangul/src/CMakeFiles/hangul.dir/engine.cpp.o -MF fcitx5-hangul/src/CMakeFiles/hangul.dir/engine.cpp.o.d -o fcitx5-hangul/src/CMakeFiles/hangul.dir/engine.cpp.o -c /Users/liumeo/github/fcitx5-plugins/fcitx5-hangul/src/engine.cpp
In file included from /Users/liumeo/github/fcitx5-plugins/fcitx5-hangul/src/engine.cpp:8:
In file included from /Users/liumeo/github/fcitx5-plugins/fcitx5-hangul/src/engine.h:10:
In file included from /Users/liumeo/github/fcitx5-plugins/build/js/usr/include/Fcitx5/Config/fcitx-config/iniparser.h:11:
/Users/liumeo/github/emsdk/upstream/emscripten/cache/sysroot/include/c++/v1/string:820:42: error: implicit instantiation of undefined template 'std::char_traits<unsigned int>'
  820 |   static_assert(is_same<_CharT, typename traits_type::char_type>::value,
      |                                          ^
/Users/liumeo/github/fcitx5-plugins/fcitx5-hangul/src/engine.cpp:41:19: note: in instantiation of template class 'std::basic_string<unsigned int>' requested here
   41 |     for (auto c : ustr) {
      |                   ^
/Users/liumeo/github/emsdk/upstream/emscripten/cache/sysroot/include/c++/v1/__fwd/string.h:23:29: note: template is declared here
   23 | struct _LIBCPP_TEMPLATE_VIS char_traits;
      |                             ^
```