### PR TITLE
fix: forward backspace on empty composition for auto-repeat events

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -392,6 +392,17 @@ public:
                 if (preedit_len > 0) {
                     preedit_.pop_back();
                     keyUsed = true;
+                } else if (keyEvent.rawKey().states().test(
+                               KeyState::Repeat)) {
+                    // Composition is empty and this is a synthesized
+                    // auto-repeat backspace. Natural propagation works for
+                    // single presses, but on Wayland the auto-repeat handler
+                    // sends a RELEASE before deciding to forward the PRESS,
+                    // and many clients drop the resulting orphan pairs.
+                    // Explicitly forward the key so the app reliably deletes
+                    // one previously committed character per repeat.
+                    ic_->forwardKey(Key(FcitxKey_BackSpace));
+                    keyUsed = true;
                 }
             }
         } else {

--- a/test/testhangul.cpp
+++ b/test/testhangul.cpp
@@ -53,6 +53,141 @@ void scheduleEvent(Instance *instance) {
         instance->deactivate();
     });
 
+    // Backspace propagation test.
+    // Expectation per requirements.md: while composing, backspace clears the
+    // composition jamo-by-jamo and is consumed by the IME; once the buffer is
+    // empty the next backspace should propagate to the application so that
+    // press-and-hold seamlessly continues deleting previously committed text.
+    instance->eventDispatcher().schedule([instance]() {
+        auto *testfrontend = instance->addonManager().addon("testfrontend");
+        auto uuid = testfrontend->call<ITestFrontend::createInputContext>(
+            "backspace-test");
+        auto *ic = instance->inputContextManager().findByUUID(uuid);
+
+        // Activate hangul on this fresh context.
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("Control+space"), false));
+        FCITX_ASSERT(instance->inputMethod(ic) == "hangul");
+
+        // No composition yet → backspace must propagate (not consumed).
+        FCITX_ASSERT(!testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key(FcitxKey_BackSpace), false));
+
+        // Type "rk" → 가 in dubeolsik (ㄱ + ㅏ).
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("r"), false));
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("k"), false));
+
+        // Backspace 1: 가 → ㄱ, consumed.
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key(FcitxKey_BackSpace), false));
+        // Backspace 2: ㄱ → empty, consumed.
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key(FcitxKey_BackSpace), false));
+        // Backspace 3: empty buffer → must propagate.
+        FCITX_ASSERT(!testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key(FcitxKey_BackSpace), false));
+
+        // Type a 3-jamo syllable "gks" → 한 (ㅎ + ㅏ + ㄴ).
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("g"), false));
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("k"), false));
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("s"), false));
+        // Need 3 backspaces to empty: 한 → 하 → ㅎ → empty.
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key(FcitxKey_BackSpace), false));
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key(FcitxKey_BackSpace), false));
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key(FcitxKey_BackSpace), false));
+        // 4th propagates.
+        FCITX_ASSERT(!testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key(FcitxKey_BackSpace), false));
+
+        instance->deactivate();
+    });
+
+    // Typing-then-backspace: commit something to the app, then test that
+    // backspace immediately propagates so the app can delete it. This is the
+    // exact "press-and-hold past the buffer" scenario in requirements.md.
+    instance->eventDispatcher().schedule([instance]() {
+        auto *testfrontend = instance->addonManager().addon("testfrontend");
+        auto uuid = testfrontend->call<ITestFrontend::createInputContext>(
+            "commit-then-backspace");
+        auto *ic = instance->inputContextManager().findByUUID(uuid);
+
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("Control+space"), false));
+        FCITX_ASSERT(instance->inputMethod(ic) == "hangul");
+
+        // Type "rk" → 가 in composition. Then any non-hangul key forces a
+        // flush, committing 가 to the app.
+        testfrontend->call<ITestFrontend::pushCommitExpectation>("가");
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("r"), false));
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("k"), false));
+        // 1 (digit) is not a Korean jamo; engine flushes 가, propagates the 1.
+        FCITX_ASSERT(!testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("1"), false));
+
+        // Now composition is empty and 가 was committed. Backspace must
+        // propagate so the app can delete it.
+        FCITX_ASSERT(!testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key(FcitxKey_BackSpace), false));
+
+        instance->deactivate();
+    });
+
+    // Repeat-on-empty-buffer test. Regression for the press-and-hold bug
+    // where Wayland frontends drop synthesized RELEASE/PRESS pairs for
+    // auto-repeated backspace events. The engine works around this by
+    // explicitly forwarding the key (which consumes the event) when the
+    // composition buffer is already empty and the event is a repeat. A single
+    // (non-repeat) press on the same empty buffer must still propagate
+    // naturally so unrelated edge cases keep working.
+    instance->eventDispatcher().schedule([instance]() {
+        auto *testfrontend = instance->addonManager().addon("testfrontend");
+        auto uuid = testfrontend->call<ITestFrontend::createInputContext>(
+            "backspace-repeat");
+        auto *ic = instance->inputContextManager().findByUUID(uuid);
+
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("Control+space"), false));
+        FCITX_ASSERT(instance->inputMethod(ic) == "hangul");
+
+        // Single press on empty composition: must propagate (consumed=false).
+        FCITX_ASSERT(!testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key(FcitxKey_BackSpace), false));
+
+        // Auto-repeat press on empty composition: must be consumed by the
+        // workaround so the engine can forwardKey on the app's behalf.
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key(FcitxKey_BackSpace, KeyState::Repeat), false));
+
+        // While composition is non-empty, both single and repeat presses
+        // should still consume normally (clearing one jamo each).
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("r"), false));
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("k"), false));
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key(FcitxKey_BackSpace, KeyState::Repeat), false));
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key(FcitxKey_BackSpace), false));
+        // Buffer is now empty again. A repeat must consume (workaround).
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key(FcitxKey_BackSpace, KeyState::Repeat), false));
+        // And a single press at the same point must still propagate.
+        FCITX_ASSERT(!testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key(FcitxKey_BackSpace), false));
+
+        instance->deactivate();
+    });
+
     instance->eventDispatcher().schedule([instance]() { instance->exit(); });
 }
 


### PR DESCRIPTION
## Summary

Press-and-hold backspace through composition on Wayland stops at the boundary instead of continuing through previously committed text. After the composition buffer empties, each subsequent repeated backspace fails to delete a previous character in clients like KWrite (Qt) and Chrome (Chromium).

## Root cause

The fcitx5 Wayland frontend's auto-repeat loop in [`waylandimserverv2.cpp`](https://github.com/fcitx/fcitx5/blob/master/src/frontend/waylandim/waylandimserverv2.cpp) emits a `RELEASE` first on every repeat cycle and only emits the corresponding `PRESS` if the IME rejects the event:

```cpp
sendKeyToVK(repeatTime_, event.rawKey(), WL_KEYBOARD_KEY_STATE_RELEASED);
if (!ic->keyEvent(event)) {
    sendKeyToVK(repeatTime_, event.rawKey(), WL_KEYBOARD_KEY_STATE_PRESSED);
}
```

For the press-and-hold backspace sequence:
1. Initial `PRESS`: IME consumes (clears one jamo). Client never sees a `PRESS`.
2. Each repeat while composing: `RELEASE` is emitted; IME consumes; no `PRESS`. Client sees only orphan `RELEASE` events.
3. First repeat after the buffer empties: `RELEASE` + `PRESS` emitted. From here on the client receives `RELEASE` + `PRESS` pairs without ever seeing the initial `PRESS`.

Qt and Chromium clients drop the orphan pairs, so the held key never deletes any previously committed characters.

## Fix

In the backspace handler, when the composition buffer is empty *and* the raw key carries `KeyState::Repeat`, explicitly call `ic_->forwardKey(Key(FcitxKey_BackSpace))` and mark the event as used. `forwardKey` routes through `WaylandIMInputContextV2::forwardKeyDelegate` which always emits a complete `PRESS`+`RELEASE` pair that clients handle correctly.

Single presses keep the original behavior (engine does not consume, natural propagation handles it), so non-Wayland frontends and the X11/XIM path are unaffected.

The workaround is safe even after the upstream Wayland frontend is eventually fixed: `forwardKey` + `filterAndAccept` blocks the natural propagation, so there is no double-deletion regardless of frontend behavior.

## Test plan

- [x] `ctest` regression test covering both empty-buffer single press (must propagate) and empty-buffer repeat press (must be consumed via `forwardKey`), plus the same checks after a fresh composition cycle.
- [x] Manual verification on KDE Plasma 6 Wayland with KWrite: typing `헬로우한` and holding backspace now deletes through `헬로우한 → 헬로우하 → 헬로우ㅎ → 헬로우 → 헬로 → 헬 → empty`, matching expected behavior.

## Note

The underlying frontend behavior likely affects other composition-based input methods (pinyin, anthy, mozc, etc.) on Wayland. A frontend-level fix in `fcitx5` itself would be ideal; this PR is a targeted workaround for fcitx5-hangul where the symptom is most commonly hit.